### PR TITLE
Fix unpkg links

### DIFF
--- a/docs/sites/demo/example-date-spiral-arc.html
+++ b/docs/sites/demo/example-date-spiral-arc.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -18,10 +18,10 @@
         <p>
             Demo of a ArcSpiral chart. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <script type="text/javascript">
-            var arcspiral = new spiral.ArcSpiral(d3.select('#spiral'));
+            var arcspiral = new spiral.ArcSpiral(d3.select('#spiralchart'));
 
             var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 

--- a/docs/sites/demo/example-date-spiral-color.html
+++ b/docs/sites/demo/example-date-spiral-color.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>

--- a/docs/sites/demo/example-date-spiral-line.html
+++ b/docs/sites/demo/example-date-spiral-line.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -18,10 +18,10 @@
         <p>
             Demo of a LineSpiral chart. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <script type="text/javascript">
-			var linespiral = new spiral.LineSpiral(d3.select('#spiral'));
+			var linespiral = new spiral.LineSpiral(d3.select('#spiralchart'));
 
 			var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 

--- a/docs/sites/demo/example-date-spiral-slider.html
+++ b/docs/sites/demo/example-date-spiral-slider.html
@@ -8,8 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <!-- <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.js"></script> -->
-        <script type="text/javascript" src="../spiraljs/dist/spiral.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -19,7 +18,7 @@
         <p>
             Demo of a ArcSpiral chart. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <!-- slide between period of one minute to about a month -->
         <div id="slider">
@@ -48,7 +47,7 @@
         </script>
 
         <script type="text/javascript">
-            var arcspiral = new spiral.ArcSpiral(d3.select('#spiral'));
+            var arcspiral = new spiral.ArcSpiral(d3.select('#spiralchart'));
 
             var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 

--- a/docs/sites/demo/example-date-spiral-weight.html
+++ b/docs/sites/demo/example-date-spiral-weight.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -18,10 +18,10 @@
         <p>
             Demo of a BubbleSpiral chart with weighted bubbles. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <script type="text/javascript">
-			var bubblespiral = new spiral.BubbleSpiral(d3.select('#spiral'));
+			var bubblespiral = new spiral.BubbleSpiral(d3.select('#spiralchart'));
 
 			var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "homepage": "https://github.com/nlesc-sherlock/spiraljs-demo#readme",
   "dependencies": {
     "d3": "^3.5.17",
-    "spiraljs": "^1.0.0-alpha.4"
+    "spiraljs": "^1.0.0-alpha.5"
   }
 }

--- a/src/example-date-spiral-arc.html
+++ b/src/example-date-spiral-arc.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -18,10 +18,10 @@
         <p>
             Demo of a ArcSpiral chart. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <script type="text/javascript">
-            var arcspiral = new spiral.ArcSpiral(d3.select('#spiral'));
+            var arcspiral = new spiral.ArcSpiral(d3.select('#spiralchart'));
 
             var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 

--- a/src/example-date-spiral-color.html
+++ b/src/example-date-spiral-color.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>

--- a/src/example-date-spiral-line.html
+++ b/src/example-date-spiral-line.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -18,10 +18,10 @@
         <p>
             Demo of a LineSpiral chart. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <script type="text/javascript">
-			var linespiral = new spiral.LineSpiral(d3.select('#spiral'));
+			var linespiral = new spiral.LineSpiral(d3.select('#spiralchart'));
 
 			var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 

--- a/src/example-date-spiral-slider.html
+++ b/src/example-date-spiral-slider.html
@@ -8,8 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <!-- <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.js"></script> -->
-        <script type="text/javascript" src="../spiraljs/dist/spiral.js"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -19,7 +18,7 @@
         <p>
             Demo of a ArcSpiral chart. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <!-- slide between period of one minute to about a month -->
         <div id="slider">
@@ -48,7 +47,7 @@
         </script>
 
         <script type="text/javascript">
-            var arcspiral = new spiral.ArcSpiral(d3.select('#spiral'));
+            var arcspiral = new spiral.ArcSpiral(d3.select('#spiralchart'));
 
             var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 

--- a/src/example-date-spiral-weight.html
+++ b/src/example-date-spiral-weight.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.css">
 
         <script type="text/javascript" src="https://unpkg.com/d3@^3.5.17/d3.min.js"></script>
-        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4"></script>
+        <script type="text/javascript" src="https://unpkg.com/spiraljs@1.0.0-alpha.4/dist/spiral.min.js"></script>
 
         <!-- load local data -->
         <script type="text/javascript" src="data.js"></script>
@@ -18,10 +18,10 @@
         <p>
             Demo of a BubbleSpiral chart with weighted bubbles. Uses d3@^3.5.17 and spiraljs@1.0.0-alpha.4.
         </p>
-        <div id="spiral"></div>
+        <div id="spiralchart"></div>
 
         <script type="text/javascript">
-			var bubblespiral = new spiral.BubbleSpiral(d3.select('#spiral'));
+			var bubblespiral = new spiral.BubbleSpiral(d3.select('#spiralchart'));
 
 			var extent = d3.extent(data, (record) => { return new Date(record.datestr); })
 


### PR DESCRIPTION
content from npmjs is now retrieved by linking to files inside the spiraljs package directly from the src tag in the html